### PR TITLE
fix(backend): add missing metadata and scripts to package.json

### DIFF
--- a/b/package.json
+++ b/b/package.json
@@ -1,4 +1,12 @@
 {
+  "name": "bharatconnect-backend",
+  "version": "1.0.0",
+  "description": "Backend API for BharatConnect Transportation & Logistics Platform",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "nodemon index.js"
+  },
   "dependencies": {
     "@google/genai": "^1.33.0",
     "@google/generative-ai": "^0.24.1",


### PR DESCRIPTION
## Summary
Fixes #5

The package.json was missing standard npm package fields.

## Changes
- Added 
ame, version, and description metadata
- Added main entry point (index.js)
- Added scripts:

npm start → runs node index.js
 
npm run dev → runs nodemon index.js

## Testing
Run from the / directory:

npm run dev

Server should start on port 4500.